### PR TITLE
Update gitattributes:  Disable LF normalization for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
-* text=auto
+# Disable LF normalization for all files
+* -text
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
Allow for Line feed normalization being turned off.  Not an issue, unless you are using a mac.